### PR TITLE
Add bugfixes

### DIFF
--- a/src/main/java/seedu/duke/Constants.java
+++ b/src/main/java/seedu/duke/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
                     + System.lineSeparator() + EXCEPTION_INDENT
                     + "(At least one symptom, diagnosis or prescription must be specified)";
     public static final String INVALID_INPUT_INVALID_DATE = "Please provide a valid date (format: dd/MM/yyyy).";
+    public static final String INVALID_INPUT_END_OF_FILE = "End of file reached, exiting application.";
 
     public static final String STORAGE = "Something wrong happen when trying to save/load data";
     public static final String STORAGE_FILE_CREATION_FAIL = "Failed to create a save file.";

--- a/src/main/java/seedu/duke/Constants.java
+++ b/src/main/java/seedu/duke/Constants.java
@@ -49,16 +49,17 @@ public class Constants {
 
     // Exception messages
     public static final String EXCEPTION_INDENT = "\t";
-    
+
     public static final String INVALID_INPUT = "Input command and/or arguments are invalid";
     public static final String INVALID_INPUT_EMPTY_STRING = "Please enter something for me to process!";
     public static final String INVALID_INPUT_UNKNOWN_COMMAND = "Invalid command is provided!";
     public static final String INVALID_INPUT_INVALID_NRIC = "Please key in a valid NRIC number!";
     public static final String INVALID_INPUT_PATIENT_EXISTED = "Patient already exists!";
     public static final String INVALID_INPUT_NO_PATIENT_LOADED = "No patient loaded!";
-    public static final String INVALID_INPUT_EMPTY_DESCRIPTION = "Please provide more details about the patient's visit!"
-            + System.lineSeparator() + EXCEPTION_INDENT
-            + "(At least one symptom, diagnosis or prescription must be specified)";
+    public static final String INVALID_INPUT_EMPTY_DESCRIPTION =
+            "Please provide more details about the patient's visit!"
+                    + System.lineSeparator() + EXCEPTION_INDENT
+                    + "(At least one symptom, diagnosis or prescription must be specified)";
     public static final String INVALID_INPUT_INVALID_DATE = "Please provide a valid date (format: dd/MM/yyyy).";
 
     public static final String STORAGE = "Something wrong happen when trying to save/load data";

--- a/src/main/java/seedu/duke/Constants.java
+++ b/src/main/java/seedu/duke/Constants.java
@@ -56,7 +56,9 @@ public class Constants {
     public static final String INVALID_INPUT_INVALID_NRIC = "Please key in a valid NRIC number!";
     public static final String INVALID_INPUT_PATIENT_EXISTED = "Patient already exists!";
     public static final String INVALID_INPUT_NO_PATIENT_LOADED = "No patient loaded!";
-    public static final String INVALID_INPUT_EMPTY_DESCRIPTION = "Please provide details about the patient's visit!";
+    public static final String INVALID_INPUT_EMPTY_DESCRIPTION = "Please provide more details about the patient's visit!"
+            + System.lineSeparator() + EXCEPTION_INDENT
+            + "(At least one symptom, diagnosis or prescription must be specified)";
     public static final String INVALID_INPUT_INVALID_DATE = "Please provide a valid date (format: dd/MM/yyyy).";
 
     public static final String STORAGE = "Something wrong happen when trying to save/load data";
@@ -88,7 +90,6 @@ public class Constants {
     public static final String SYMPTOM_KEY = "s";
     public static final String DIAGNOSIS_KEY = "d";
     public static final String PRESCRIPTION_KEY = "p";
-    public static final String EXCEPTION_RECORD_RETRIEVE_INVALID_DATE = "That's not a valid date";
 
     // Date format
     public static final String DATE_PATTERN = "dd/MM/yyyy";

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -55,7 +55,6 @@ public class Parser {
      * @see Command
      */
     public Command parse(String fullCommand) throws InvalidInputException, UnknownException {
-        HashMap<String, String> arguments = new HashMap<>();
         String[] tokens = fullCommand.split("\\s+");
 
         // If tokenized command returns an empty array, raise an exception
@@ -69,6 +68,8 @@ public class Parser {
         if (tokens.length == 0) {
             throw new InvalidInputException(InvalidInputException.Type.EMPTY_STRING);
         }
+
+        HashMap<String, String> arguments = new HashMap<>();
         arguments.put("command", tokens[0]);
 
         // Default key is "payload"

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -10,6 +10,7 @@ import seedu.duke.exception.InvalidInputException;
 import seedu.duke.exception.UnknownException;
 
 /* Adapted from https://github.com/fsgmhoward/ip/blob/master/src/main/java/duke/Parser.java */
+
 /**
  * This is the parser for parsing the line of command to tokens and construct the command class.
  */
@@ -25,7 +26,8 @@ public class Parser {
 
     /**
      * This is the constructor of the Parser class.
-     * @param ui Ui instance which will be passed to the command instances
+     *
+     * @param ui   Ui instance which will be passed to the command instances
      * @param data Data instance which will be passed to the command instances
      */
     public Parser(Ui ui, Data data) {
@@ -47,6 +49,7 @@ public class Parser {
      * Then, ui, tasks and this argument hashmap will be passed to initialize a command class.
      * The command class is determined by the 1st token of the command string. For example, for a command string 'find',
      * command class 'duke.command.FindCommand' will be initialized.
+     *
      * @param fullCommand The line of command to be parsed
      * @return A Command instance which is ready to be executed
      * @see Command
@@ -54,6 +57,11 @@ public class Parser {
     public Command parse(String fullCommand) throws InvalidInputException, UnknownException {
         HashMap<String, String> arguments = new HashMap<>();
         String[] tokens = fullCommand.split("\\s+");
+
+        // If tokenized command returns an empty array, raise an exception
+        if (tokens.length == 0) {
+            throw new InvalidInputException(InvalidInputException.Type.EMPTY_STRING);
+        }
         // If first token (command) is empty, there are empty spaces typed in at the front - so we remove it
         if (tokens[0].isEmpty()) {
             tokens = Arrays.copyOfRange(tokens, 1, tokens.length);
@@ -67,15 +75,16 @@ public class Parser {
         String key = "payload";
         ArrayList<String> values = new ArrayList<>();
         for (int i = 1; i < tokens.length; ++i) {
+            String token = tokens[i];
             // Check whether this token is a new key
-            if (tokens[i].charAt(0) == '/') {
+            if (!token.isEmpty() && token.charAt(0) == '/') {
                 // If it is, save current value into the map and start a new k-v pair
                 arguments.put(key, String.join(DELIMITER, values));
-                key = tokens[i].substring(1);
+                key = token.substring(1);
                 values.clear();
             } else {
                 // If not, append this token to the end of the value
-                values.add(tokens[i]);
+                values.add(token);
             }
         }
 

--- a/src/main/java/seedu/duke/PatientManager.java
+++ b/src/main/java/seedu/duke/PatientManager.java
@@ -1,6 +1,7 @@
 package seedu.duke;
 
 import seedu.duke.command.Command;
+import seedu.duke.exception.InvalidInputException;
 import seedu.duke.exception.StorageException;
 
 /**
@@ -40,9 +41,15 @@ public class PatientManager {
         ui.printWelcome();
 
         while (true) {
-            String fullCommand = ui.readInput();
+            String fullCommand = null;
+            try {
+                fullCommand = ui.readInput();
+            } catch (InvalidInputException invalidInputException) {
+                ui.printException(invalidInputException);
+                break;
+            }
             if (fullCommand == null) {
-                // Reached EOF but no exit command is executed - we still exit
+                // Reached EOF from text ui tests but no exit command is executed - we still exit
                 break;
             }
 

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -1,5 +1,8 @@
 package seedu.duke;
 
+import seedu.duke.exception.InvalidInputException;
+
+import java.util.NoSuchElementException;
 import java.util.Scanner;
 
 /**
@@ -17,10 +20,17 @@ public class Ui {
 
     /**
      * Returns user input as a String.
+     *
      * @return user input
      */
-    public String readInput() {
-        return userInputScanner.nextLine();
+    public String readInput() throws InvalidInputException {
+        String userInput = null;
+        try {
+            userInput = userInputScanner.nextLine();
+        } catch (NoSuchElementException noSuchElementException) {
+            throw new InvalidInputException(InvalidInputException.Type.END_OF_FILE, noSuchElementException);
+        }
+        return userInput;
     }
 
     /**
@@ -32,6 +42,7 @@ public class Ui {
 
     /**
      * Prints the String specified in @param.
+     *
      * @param message String to be printed
      */
     public void printMessage(String message) {
@@ -48,6 +59,7 @@ public class Ui {
 
     /**
      * Prints the exception message specified in @param.
+     *
      * @param e Exception to be printed
      */
     public void printException(Exception e) {

--- a/src/main/java/seedu/duke/command/AddCommand.java
+++ b/src/main/java/seedu/duke/command/AddCommand.java
@@ -54,7 +54,7 @@ public class AddCommand extends Command {
         if (stringLength != Constants.ID_NUMBER_OF_CHARACTERS) {
             return false;
         }
-        
+
         int checksum = 0;
         char firstLetter = id.charAt(Constants.INDEX_OF_FIRST_CHARACTER);
         char[] st = {'J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'};

--- a/src/main/java/seedu/duke/command/AddCommand.java
+++ b/src/main/java/seedu/duke/command/AddCommand.java
@@ -49,15 +49,16 @@ public class AddCommand extends Command {
      */
     private boolean checkID(String id) {
         int stringLength = id.length();
-        int checksum = 0;
-        char firstLetter = id.charAt(Constants.INDEX_OF_FIRST_CHARACTER);
-        char[] st = {'J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'};
-        char[] fg = {'X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'};
 
         // Checks if ID has 9 characters
         if (stringLength != Constants.ID_NUMBER_OF_CHARACTERS) {
             return false;
         }
+        
+        int checksum = 0;
+        char firstLetter = id.charAt(Constants.INDEX_OF_FIRST_CHARACTER);
+        char[] st = {'J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'};
+        char[] fg = {'X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'};
         // Checks if ID is valid
         for (int i = 0; i < stringLength; i++) {
             char c = id.charAt(i);

--- a/src/main/java/seedu/duke/command/RecordCommand.java
+++ b/src/main/java/seedu/duke/command/RecordCommand.java
@@ -52,17 +52,23 @@ public class RecordCommand extends Command {
         return LocalDate.now();
     }
 
-    private void addRecord(Patient patient, LocalDate date) {
+    private void addRecord(Patient patient, LocalDate date) throws InvalidInputException {
         String symptom = null;
         String diagnosis = null;
         String prescription = null;
-        if (arguments.containsKey(Constants.SYMPTOM_KEY)) {
+        boolean containsSymptom = arguments.containsKey(Constants.SYMPTOM_KEY);
+        boolean containsDiagnosis = arguments.containsKey(Constants.DIAGNOSIS_KEY);
+        boolean containsPrescription = arguments.containsKey(Constants.PRESCRIPTION_KEY);
+        if (!containsSymptom && !containsDiagnosis && !containsPrescription) {
+            throw new InvalidInputException(InvalidInputException.Type.EMPTY_DESCRIPTION);
+        }
+        if (containsSymptom) {
             symptom = arguments.get(Constants.SYMPTOM_KEY);
         }
-        if (arguments.containsKey(Constants.DIAGNOSIS_KEY)) {
+        if (containsDiagnosis) {
             diagnosis = arguments.get(Constants.DIAGNOSIS_KEY);
         }
-        if (arguments.containsKey(Constants.PRESCRIPTION_KEY)) {
+        if (containsPrescription) {
             prescription = arguments.get(Constants.PRESCRIPTION_KEY);
         }
         patient.addRecord(date, symptom, diagnosis, prescription);

--- a/src/main/java/seedu/duke/exception/InvalidInputException.java
+++ b/src/main/java/seedu/duke/exception/InvalidInputException.java
@@ -11,7 +11,8 @@ public class InvalidInputException extends BaseException {
         PATIENT_EXISTED(Constants.INVALID_INPUT_PATIENT_EXISTED),
         NO_PATIENT_LOADED(Constants.INVALID_INPUT_NO_PATIENT_LOADED),
         EMPTY_DESCRIPTION(Constants.INVALID_INPUT_EMPTY_DESCRIPTION),
-        INVALID_DATE(Constants.INVALID_INPUT_INVALID_DATE);
+        INVALID_DATE(Constants.INVALID_INPUT_INVALID_DATE),
+        END_OF_FILE(Constants.INVALID_INPUT_END_OF_FILE);
 
         public final String message;
 


### PR DESCRIPTION
Fix the following bugs:

- `record` without any arguments will now be recognized as a invalid command
- ^D, ^Z will be recognized as an EOF character and terminate the program
- Pure whitespace command (e.g.`    `) tokenizes into an empty array, will immediately raise an exception
- `add` with an empty string will immediately fail the validity check