### PR TITLE
Improve Unit Tests

### DIFF
--- a/src/main/java/seedu/duke/Common.java
+++ b/src/main/java/seedu/duke/Common.java
@@ -114,4 +114,14 @@ public class Common {
         }
         return date;
     }
+
+    /**
+     * Converts the specified date into a string following the format dd/MM/yyyy.
+     *
+     * @param date the date to be formatted
+     * @return a string representation of the date, in the format dd/MM/yyyy
+     */
+    public static String formatDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(Constants.DATE_PATTERN));
+    }
 }

--- a/src/main/java/seedu/duke/Common.java
+++ b/src/main/java/seedu/duke/Common.java
@@ -1,11 +1,19 @@
 package seedu.duke;
 
+import seedu.duke.exception.InvalidInputException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+
 /**
  * This is a common class providing some miscellaneous functionalities.
  */
 public class Common {
     /**
      * Checks whether the patient's ID is valid.
+     *
      * @param id Unique identifier of the patient to be retrieved
      * @return Flag on whether the patient's ID is valid
      */
@@ -78,5 +86,32 @@ public class Common {
             }
         }
         return true;
+    }
+
+    /**
+     * Parses a string in the format dd/MM/yyyy, and returns its corresponding date.
+     *
+     * @param dateString the string to be parsed
+     * @return a LocalDate object corresponding to the input string
+     * @throws DateTimeParseException if the date provided is invalid
+     */
+    public static LocalDate parseDate(String dateString) throws InvalidInputException {
+        if (dateString.isEmpty()) {
+            return LocalDate.now();
+        }
+        LocalDate date = null;
+        try {
+            date = LocalDate.parse(
+                    dateString,
+                    DateTimeFormatter.ofPattern(Constants.DATE_PATTERN).withResolverStyle(ResolverStyle.STRICT)
+            );
+        } catch (DateTimeParseException e) {
+            throw new InvalidInputException(InvalidInputException.Type.INVALID_DATE, e);
+        }
+        if (date.isAfter(LocalDate.now())) {
+            // We don't allow a record to be inserted for a future date
+            throw new InvalidInputException(InvalidInputException.Type.FUTURE_DATE);
+        }
+        return date;
     }
 }

--- a/src/main/java/seedu/duke/Constants.java
+++ b/src/main/java/seedu/duke/Constants.java
@@ -1,6 +1,13 @@
 package seedu.duke;
 
 public class Constants {
+
+    // String constants for the main class
+    public static final String EXIT_MESSAGE = "Goodbye, we hope to see you again!";
+    public static final String WELCOME_MESSAGE = "Welcome to the Patient Manager.\n";
+    public static final String INPUT_PROMPT = "Please input a command: ";
+
+    // Help messages
     public static final String ADD_INFO_MESSAGE = "Add a patient to the list\n"
             + "Command prefix: add\n"
             + "Argument(s): IC number\n"
@@ -39,9 +46,6 @@ public class Constants {
             + "Usage: exit\n";
 
     public static final String INVALID_COMMAND_MESSAGE = "Invalid command: %s";
-    public static final String EXIT_MESSAGE = "Goodbye, we hope to see you again!";
-    public static final String WELCOME_MESSAGE = "Welcome to the Patient Manager.\n";
-    public static final String INPUT_PROMPT = "Please input a command: ";
 
     public static final String EMPTY_LIST_MESSAGE = "List is currently empty!";
 
@@ -51,22 +55,21 @@ public class Constants {
     public static final String EXCEPTION_INDENT = "\t";
 
     public static final String INVALID_INPUT = "Input command and/or arguments are invalid";
-    public static final String INVALID_INPUT_EMPTY_STRING = "Please enter something for me to process!";
-    public static final String INVALID_INPUT_UNKNOWN_COMMAND = "Invalid command is provided!";
-    public static final String INVALID_INPUT_INVALID_NRIC = "Please key in a valid NRIC number!";
-    public static final String INVALID_INPUT_PATIENT_EXISTED = "Patient already exists!";
-    public static final String INVALID_INPUT_NO_PATIENT_LOADED = "No patient loaded!";
+    public static final String INVALID_INPUT_EMPTY_STRING = "Please enter a command for me to process";
+    public static final String INVALID_INPUT_UNKNOWN_COMMAND = "Invalid command provided";
+    public static final String INVALID_INPUT_INVALID_NRIC = "Please key in a valid NRIC number";
+    public static final String INVALID_INPUT_PATIENT_EXISTED = "Patient already exists";
+    public static final String INVALID_INPUT_NO_PATIENT_LOADED =
+            "Please load a patient with the load command before adding or viewing records";
     public static final String INVALID_INPUT_EMPTY_DESCRIPTION =
-            "Please provide more details about the patient's visit!"
-            + System.lineSeparator() + EXCEPTION_INDENT
-            + "(At least one symptom, diagnosis or prescription must be specified)";
-    public static final String INVALID_INPUT_INVALID_DATE = 
-            "Please provide a valid date (format: dd/MM/yyyy)."
-            + System.lineSeparator() + EXCEPTION_INDENT
-            + "It should also be a valid date in the Gregorian calendar.";
+            "Please provide more details about the patient's visit!\n"
+                    + "(At least one symptom, diagnosis or prescription must be specified)";
+    public static final String INVALID_INPUT_INVALID_DATE =
+            "Please provide a valid date (format: dd/MM/yyyy).\n"
+                    + "It should also be a valid date in the Gregorian calendar.";
     public static final String INVALID_FUTURE_DATE = "You cannot save a visit record for a future date.";
-    public static final String INVALID_INPUT_UNKNOWN_DELETE_ARGUMENT = "Kindly use /p or /r to indicate patient or "
-            + "record, refer to help for more clarification!";
+    public static final String INVALID_INPUT_UNKNOWN_DELETE_ARGUMENT =
+            "Kindly use /p or /r to indicate patient or record, refer to help for more clarification";
     public static final String INVALID_INPUT_PATIENT_NOT_FOUND = "Patient with this IC number does not exist!";
     public static final String INVALID_INPUT_END_OF_FILE = "End of file reached, exiting application.";
 

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -106,12 +106,16 @@ public class Parser {
             Constructor<?> constructor = cls.getDeclaredConstructor(Ui.class, Data.class, HashMap.class);
             Object obj = constructor.newInstance(ui, data, arguments);
             return (Command) obj;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException classNotFoundException) {
             // *Command class cannot be found!
-            throw new InvalidInputException(InvalidInputException.Type.UNKNOWN_COMMAND, e);
-        } catch (Exception e) {
+            throw new InvalidInputException(InvalidInputException.Type.UNKNOWN_COMMAND, classNotFoundException);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // *Command class can be found, but doesn't contain a constructor
+            throw new InvalidInputException(InvalidInputException.Type.UNKNOWN_COMMAND, noSuchMethodException);
+        } catch (Exception exception) {
             // Some other weird error occurred here
-            throw new UnknownException(e);
+            // We should NEVER reach this block, if we do, log under the highest level
+            throw new UnknownException(exception);
         }
     }
 }

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -58,12 +58,12 @@ public class Ui {
     }
 
     /**
-     * Prints the exception message specified in @param.
+     * Prints a detailed error message for the exception specified in @param.
      *
-     * @param e Exception to be printed
+     * @param exception Exception to be printed
      */
-    public void printException(Exception e) {
-        String errorMessage = e.getMessage();
+    public void printException(Exception exception) {
+        String errorMessage = exception.getMessage();
         String[] errorLines = errorMessage.split("\n");
         for (String errorLine : errorLines) {
             printMessage(Constants.EXCEPTION_INDENT + errorLine);

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -63,11 +63,7 @@ public class Ui {
      * @param exception Exception to be printed
      */
     public void printException(Exception exception) {
-        String errorMessage = exception.getMessage();
-        String[] errorLines = errorMessage.split("\n");
-        for (String errorLine : errorLines) {
-            printMessage(Constants.EXCEPTION_INDENT + errorLine);
-        }
+        printMessage(exception.toString());
     }
 
     /**

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -63,7 +63,11 @@ public class Ui {
      * @param e Exception to be printed
      */
     public void printException(Exception e) {
-        printMessage(e.toString());
+        String errorMessage = e.getMessage();
+        String[] errorLines = errorMessage.split("\n");
+        for (String errorLine : errorLines) {
+            printMessage(Constants.EXCEPTION_INDENT + errorLine);
+        }
     }
 
     /**

--- a/src/main/java/seedu/duke/command/DeleteCommand.java
+++ b/src/main/java/seedu/duke/command/DeleteCommand.java
@@ -1,5 +1,6 @@
 package seedu.duke.command;
 
+import seedu.duke.Common;
 import seedu.duke.Constants;
 import seedu.duke.Data;
 import seedu.duke.Ui;
@@ -8,7 +9,6 @@ import seedu.duke.exception.StorageException;
 import seedu.duke.model.Patient;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 
@@ -67,7 +67,7 @@ public class DeleteCommand extends Command {
     private void deleteRecord(Patient patient, String dateString) throws InvalidInputException {
         LocalDate date = null;
         try {
-            date = parseDate(dateString);
+            date = Common.parseDate(dateString);
         } catch (DateTimeParseException dateTimeParseException) {
             throw new InvalidInputException(InvalidInputException.Type.INVALID_DATE);
         }
@@ -78,12 +78,5 @@ public class DeleteCommand extends Command {
             ui.printMessage("Record for " + date + " does not exist!");
         }
 
-    }
-
-    private LocalDate parseDate(String dateString) throws DateTimeParseException {
-        if (!dateString.isEmpty()) {
-            return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(Constants.DATE_PATTERN));
-        }
-        return LocalDate.now();
     }
 }

--- a/src/main/java/seedu/duke/command/ListCommand.java
+++ b/src/main/java/seedu/duke/command/ListCommand.java
@@ -28,7 +28,8 @@ public class ListCommand extends Command {
         String list = "List of patients (in alphanumeric order):";
 
         for (String patientID : patients.keySet()) {
-            list += "\n" + ++patientCount + ". " + patientID;
+            patientCount = patientCount + 1;
+            list += System.lineSeparator() + patientCount + ". " + patientID;
         }
 
         if (patientCount == 0) {

--- a/src/main/java/seedu/duke/command/RecordCommand.java
+++ b/src/main/java/seedu/duke/command/RecordCommand.java
@@ -1,5 +1,6 @@
 package seedu.duke.command;
 
+import seedu.duke.Common;
 import seedu.duke.Constants;
 import seedu.duke.Data;
 import seedu.duke.Ui;
@@ -8,9 +9,7 @@ import seedu.duke.exception.StorageException;
 import seedu.duke.model.Patient;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.format.ResolverStyle;
 import java.util.HashMap;
 
 public class RecordCommand extends Command {
@@ -35,30 +34,10 @@ public class RecordCommand extends Command {
             throw new InvalidInputException(InvalidInputException.Type.NO_PATIENT_LOADED);
         }
         String dateString = arguments.get(Constants.PAYLOAD_KEY);
-        LocalDate date = null;
-        // TODO: More test cases to test out the "invalid dates"
-        try {
-            date = parseDate(dateString);
-        } catch (DateTimeParseException e) {
-            throw new InvalidInputException(InvalidInputException.Type.INVALID_DATE, e);
-        }
-        if (date.isAfter(LocalDate.now())) {
-            // We don't allow a record to be inserted for a future date
-            throw new InvalidInputException(InvalidInputException.Type.FUTURE_DATE);
-        }
+        LocalDate date = Common.parseDate(dateString);
         addRecord(patient, date);
         data.saveFile();
         printNewRecord(patient);
-    }
-
-    private LocalDate parseDate(String dateString) throws DateTimeParseException {
-        if (!dateString.isEmpty()) {
-            return LocalDate.parse(
-                dateString,
-                DateTimeFormatter.ofPattern(Constants.DATE_PATTERN).withResolverStyle(ResolverStyle.STRICT)
-            );
-        }
-        return LocalDate.now();
     }
 
     private void addRecord(Patient patient, LocalDate date) throws InvalidInputException {

--- a/src/main/java/seedu/duke/command/RecordCommand.java
+++ b/src/main/java/seedu/duke/command/RecordCommand.java
@@ -52,9 +52,9 @@ public class RecordCommand extends Command {
         if (arguments.containsKey(Constants.PRESCRIPTION_KEY)) {
             prescription = arguments.get(Constants.PRESCRIPTION_KEY);
         }
-        boolean containsSymptom = symptom == null || symptom.isEmpty();
-        boolean containsDiagnosis = diagnosis == null || diagnosis.isEmpty();
-        boolean containsPrescription = prescription == null || prescription.isEmpty();
+        boolean containsSymptom = symptom != null && !symptom.isEmpty();
+        boolean containsDiagnosis = diagnosis != null && !diagnosis.isEmpty();
+        boolean containsPrescription = prescription != null && !prescription.isEmpty();
         if (!containsSymptom && !containsDiagnosis && !containsPrescription) {
             throw new InvalidInputException(InvalidInputException.Type.EMPTY_DESCRIPTION);
         }

--- a/src/main/java/seedu/duke/command/RecordCommand.java
+++ b/src/main/java/seedu/duke/command/RecordCommand.java
@@ -9,7 +9,6 @@ import seedu.duke.exception.StorageException;
 import seedu.duke.model.Patient;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 
 public class RecordCommand extends Command {
@@ -44,20 +43,20 @@ public class RecordCommand extends Command {
         String symptom = null;
         String diagnosis = null;
         String prescription = null;
-        boolean containsSymptom = arguments.containsKey(Constants.SYMPTOM_KEY);
-        boolean containsDiagnosis = arguments.containsKey(Constants.DIAGNOSIS_KEY);
-        boolean containsPrescription = arguments.containsKey(Constants.PRESCRIPTION_KEY);
-        if (!containsSymptom && !containsDiagnosis && !containsPrescription) {
-            throw new InvalidInputException(InvalidInputException.Type.EMPTY_DESCRIPTION);
-        }
-        if (containsSymptom) {
+        if (arguments.containsKey(Constants.SYMPTOM_KEY)) {
             symptom = arguments.get(Constants.SYMPTOM_KEY);
         }
-        if (containsDiagnosis) {
+        if (arguments.containsKey(Constants.DIAGNOSIS_KEY)) {
             diagnosis = arguments.get(Constants.DIAGNOSIS_KEY);
         }
-        if (containsPrescription) {
+        if (arguments.containsKey(Constants.PRESCRIPTION_KEY)) {
             prescription = arguments.get(Constants.PRESCRIPTION_KEY);
+        }
+        boolean containsSymptom = symptom == null || symptom.isEmpty();
+        boolean containsDiagnosis = diagnosis == null || diagnosis.isEmpty();
+        boolean containsPrescription = prescription == null || prescription.isEmpty();
+        if (!containsSymptom && !containsDiagnosis && !containsPrescription) {
+            throw new InvalidInputException(InvalidInputException.Type.EMPTY_DESCRIPTION);
         }
         patient.addRecord(date, symptom, diagnosis, prescription);
     }

--- a/src/main/java/seedu/duke/command/RetrieveCommand.java
+++ b/src/main/java/seedu/duke/command/RetrieveCommand.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class RetrieveCommand extends Command {
-    
+
     /**
      * This is the constructor of the command. Arguments are passed to parent class.
      *

--- a/src/main/java/seedu/duke/command/RetrieveCommand.java
+++ b/src/main/java/seedu/duke/command/RetrieveCommand.java
@@ -1,5 +1,6 @@
 package seedu.duke.command;
 
+import seedu.duke.Common;
 import seedu.duke.Constants;
 import seedu.duke.Data;
 import seedu.duke.Ui;
@@ -8,7 +9,6 @@ import seedu.duke.model.Patient;
 import seedu.duke.model.Record;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -43,7 +43,7 @@ public class RetrieveCommand extends Command {
     }
 
     private void printRecord(LocalDate date, Record record) {
-        ui.printMessage(date.format(DateTimeFormatter.ofPattern(Constants.DATE_PATTERN)) + ":");
+        ui.printMessage(Common.formatDate(date) + ":");
         ui.printMessage(record.toString());
     }
 }

--- a/src/main/java/seedu/duke/command/RetrieveCommand.java
+++ b/src/main/java/seedu/duke/command/RetrieveCommand.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class RetrieveCommand extends Command {
+    
     /**
      * This is the constructor of the command. Arguments are passed to parent class.
      *

--- a/src/main/java/seedu/duke/exception/BaseException.java
+++ b/src/main/java/seedu/duke/exception/BaseException.java
@@ -19,16 +19,21 @@ public abstract class BaseException extends Exception {
 
     @Override
     public String toString() {
-        String s = classMessage + ":" + System.lineSeparator()
-                + Constants.EXCEPTION_INDENT + getMessage();
+        String errorString = classMessage + ":" + System.lineSeparator();
+
+        String errorMessage = getMessage();
+        String[] errorLines = errorMessage.split("\n");
+        for (String errorLine : errorLines) {
+            errorString += Constants.EXCEPTION_INDENT + errorLine;
+        }
 
         Throwable cause = this.getCause();
         if (cause != null) {
-            s += System.lineSeparator()
+            errorString += System.lineSeparator()
                     + "... and is caused by ..." + System.lineSeparator()
                     + Constants.EXCEPTION_INDENT + cause.toString(); 
         }
 
-        return s;
+        return errorString;
     }
 }

--- a/src/test/java/seedu/duke/AddCommandTest.java
+++ b/src/test/java/seedu/duke/AddCommandTest.java
@@ -2,6 +2,7 @@ package seedu.duke;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.command.AddCommand;
+import seedu.duke.exception.InvalidInputException;
 
 import java.util.HashMap;
 import java.io.ByteArrayOutputStream;
@@ -45,7 +46,7 @@ class AddCommandTest {
         Exception exception = assertThrows(Exception.class, () -> {
             addCommand.execute();
         });
-        assertEquals("Please key in a valid NRIC number!", exception.getMessage());
+        assertEquals(Constants.INVALID_INPUT_INVALID_NRIC, exception.getMessage());
     }
 
     @Test
@@ -57,15 +58,13 @@ class AddCommandTest {
         arguments.put("payload", "S1234567D");
         AddCommand addCommand = new AddCommand(ui, data, arguments);
 
-        try {
-            addCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
-
-        Exception exception = assertThrows(Exception.class, () -> {
+        assertDoesNotThrow(() -> {
             addCommand.execute();
         });
-        assertEquals("Patient already exists!", exception.getMessage());
+
+        InvalidInputException invalidInputException = assertThrows(InvalidInputException.class, () -> {
+            addCommand.execute();
+        });
+        assertEquals(Constants.INVALID_INPUT_PATIENT_EXISTED, invalidInputException.getMessage());
     }
 }

--- a/src/test/java/seedu/duke/DeleteCommandTest.java
+++ b/src/test/java/seedu/duke/DeleteCommandTest.java
@@ -10,8 +10,9 @@ import java.util.HashMap;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DeleteCommandTest {
     @Test
@@ -30,11 +31,9 @@ public class DeleteCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             deleteCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         assertEquals("Patient S1234567D has been deleted!" + System.lineSeparator(), bos.toString());
         System.setOut(originalOut);
@@ -48,7 +47,7 @@ public class DeleteCommandTest {
         data.loadCurrentPatient(patient.getID());
         String date = "29/03/2021";
         LocalDate parseDate = LocalDate.parse(date, DateTimeFormatter.ofPattern(Constants.DATE_PATTERN));
-        patient.addRecord(parseDate, "coughing", "","");
+        patient.addRecord(parseDate, "coughing", "", "");
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("command", "delete");
         arguments.put("r", "29/03/2021");
@@ -59,11 +58,9 @@ public class DeleteCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             deleteCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         assertEquals("Record for 2021-03-29 has been deleted!" + System.lineSeparator(), bos.toString());
         System.setOut(originalOut);
@@ -80,8 +77,7 @@ public class DeleteCommandTest {
         Exception exception = assertThrows(Exception.class, () -> {
             deleteCommand.execute();
         });
-        assertEquals("Kindly use /p or /r to indicate patient or record, refer to help for more clarification!",
-                exception.getMessage());
+        assertEquals(Constants.INVALID_INPUT_UNKNOWN_DELETE_ARGUMENT, exception.getMessage());
     }
 
     @Test
@@ -115,11 +111,9 @@ public class DeleteCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             deleteCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         assertEquals("Record for 2021-03-29 does not exist!" + System.lineSeparator(), bos.toString());
         System.setOut(originalOut);

--- a/src/test/java/seedu/duke/ExitCommandTest.java
+++ b/src/test/java/seedu/duke/ExitCommandTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExitCommandTest {
@@ -23,13 +24,11 @@ public class ExitCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             exitCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
-        assertEquals("Goodbye, we hope to see you again!" + System.lineSeparator(), bos.toString());
+        assertEquals(Constants.EXIT_MESSAGE + System.lineSeparator(), bos.toString());
 
         System.setOut(originalOut);
     }

--- a/src/test/java/seedu/duke/HelpCommandTest.java
+++ b/src/test/java/seedu/duke/HelpCommandTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HelpCommandTest {
@@ -23,15 +24,13 @@ public class HelpCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             helpCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         assertEquals(Constants.LIST_INFO_MESSAGE + System.lineSeparator()
                 + Constants.ADD_INFO_MESSAGE + System.lineSeparator()
-                + Constants.EXIT_INFO_MESSAGE  + System.lineSeparator(), bos.toString());
+                + Constants.EXIT_INFO_MESSAGE + System.lineSeparator(), bos.toString());
         System.setOut(originalOut);
     }
 
@@ -48,11 +47,9 @@ public class HelpCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             helpCommand.execute();
-        } catch (Exception e) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         assertEquals(Constants.LIST_INFO_MESSAGE + System.lineSeparator()
                 + Constants.ADD_INFO_MESSAGE + System.lineSeparator()

--- a/src/test/java/seedu/duke/ListCommandTest.java
+++ b/src/test/java/seedu/duke/ListCommandTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListCommandTest {
@@ -17,7 +18,7 @@ public class ListCommandTest {
         Ui ui = new Ui();
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("command", "list");
-        
+
         ListCommand listCommand = new ListCommand(ui, data, arguments);
 
         final ByteArrayOutputStream myOut = new ByteArrayOutputStream();
@@ -43,13 +44,11 @@ public class ListCommandTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         System.setOut(new PrintStream(bos));
 
-        try {
+        assertDoesNotThrow(() -> {
             listCommand.execute();
-        } catch (Exception exception) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
-        assertEquals("List of patients (in alphanumeric order):\n"
+        assertEquals("List of patients (in alphanumeric order):" + System.lineSeparator()
                 + "1. S1234567D" + System.lineSeparator(), bos.toString());
         System.setOut(originalOut);
     }

--- a/src/test/java/seedu/duke/ParserTest.java
+++ b/src/test/java/seedu/duke/ParserTest.java
@@ -20,7 +20,7 @@ import seedu.duke.exception.UnknownException;
 import seedu.duke.model.Patient;
 
 public class ParserTest {
-    Parser defaultParser = new Parser(new Ui(), new Data());
+    Parser parser = new Parser(new Ui(), new Data());
     HashMap<String, String> sampleArguments = new HashMap<>();
 
     /**
@@ -36,7 +36,7 @@ public class ParserTest {
 
     private void checkAgainstSampleArguments(String fullCommand) {
         assertDoesNotThrow(() -> {
-            Command command = defaultParser.parse(fullCommand);
+            Command command = parser.parse(fullCommand);
             assertTrue(command instanceof EchoCommand);
             assertTrue(((EchoCommand) command).getArguments().equals(sampleArguments));
         });
@@ -48,22 +48,22 @@ public class ParserTest {
         // Test out a string with only white spaces
         String fullCommand2 = "     ";
 
-        InvalidInputException e1 = assertThrows(InvalidInputException.class, () -> {
-            defaultParser.parse(fullCommand1);
+        InvalidInputException invalidInputException1 = assertThrows(InvalidInputException.class, () -> {
+            parser.parse(fullCommand1);
         });
-        InvalidInputException e2 = assertThrows(InvalidInputException.class, () -> {
-            defaultParser.parse(fullCommand2);
+        InvalidInputException invalidInputException2 = assertThrows(InvalidInputException.class, () -> {
+            parser.parse(fullCommand2);
         });
 
-        assertEquals(Constants.INVALID_INPUT_EMPTY_STRING, e1.getMessage());
-        assertEquals(Constants.INVALID_INPUT_EMPTY_STRING, e2.getMessage());
+        assertEquals(Constants.INVALID_INPUT_EMPTY_STRING, invalidInputException1.getMessage());
+        assertEquals(Constants.INVALID_INPUT_EMPTY_STRING, invalidInputException2.getMessage());
     }
 
     @Test
     public void parse_malformedCommand_exceptionThrown() {
         String fullCommand = "malformed";
-        assertThrows(UnknownException.class, () -> {
-            defaultParser.parse(fullCommand);
+        assertThrows(InvalidInputException.class, () -> {
+            parser.parse(fullCommand);
         });
     }
 
@@ -71,7 +71,7 @@ public class ParserTest {
     public void parse_invalidCommand_exceptionThrown() {
         String fullCommand = "invalid_command a b c /p x";
         Exception e = assertThrows(InvalidInputException.class, () -> {
-            defaultParser.parse(fullCommand);
+            parser.parse(fullCommand);
         });
 
         assertEquals(Constants.INVALID_INPUT_UNKNOWN_COMMAND, e.getMessage());
@@ -129,15 +129,15 @@ public class ParserTest {
         String words = "Hi! This is PatientManager!";
         String fullCommand = "echo " + words;
         assertDoesNotThrow(() -> {
-            Command command = defaultParser.parse(fullCommand);
+            Command command = parser.parse(fullCommand);
             assertTrue(command instanceof EchoCommand);
 
             // Capture standard output
             final ByteArrayOutputStream myOut = new ByteArrayOutputStream();
             System.setOut(new PrintStream(myOut));
             command.execute();
-            final String standardOutput = myOut.toString();
-            assertEquals(words, standardOutput);
+            final String string = myOut.toString();
+            assertEquals(words, string);
         });
     }
 
@@ -162,7 +162,7 @@ public class ParserTest {
         });
 
         assertDoesNotThrow(() -> {
-            Command command = defaultParser.parse(fullCommand);
+            Command command = this.parser.parse(fullCommand);
             assertTrue(command instanceof EchoCommand);
             Data compareData = ((EchoCommand) command).getData();
             assertTrue(compareData.getPatient(nric) == null);

--- a/src/test/java/seedu/duke/RecordCommandTest.java
+++ b/src/test/java/seedu/duke/RecordCommandTest.java
@@ -2,6 +2,7 @@ package seedu.duke;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.command.RecordCommand;
+import seedu.duke.exception.InvalidInputException;
 import seedu.duke.model.Patient;
 import seedu.duke.model.Record;
 
@@ -9,8 +10,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.TreeMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class RecordCommandTest {
     @Test
@@ -24,14 +24,31 @@ class RecordCommandTest {
         arguments.put("s", "coughing");
         Ui ui = new Ui();
         RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
-        Exception exception = assertThrows(Exception.class, () -> {
+        Exception exception = assertThrows(InvalidInputException.class, () -> {
             recordCommand.execute();
         });
         assertEquals("No patient loaded!", exception.getMessage());
     }
 
     @Test
-    public void executeRecordCommand_patientLoaded_recordAdded() {
+    public void executeRecordCommand_noDetailsSpecified_exceptionThrown() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        InvalidInputException invalidInputException = assertThrows(InvalidInputException.class, () -> {
+            recordCommand.execute();
+        });
+        assertEquals(Constants.INVALID_INPUT_EMPTY_DESCRIPTION, invalidInputException.getMessage());
+    }
+
+    @Test
+    public void executeRecordCommand_onlySymptom_recordAdded() {
         Data data = new Data();
         Patient patient = new Patient("S1234567D");
         data.setPatient(patient);
@@ -42,12 +59,89 @@ class RecordCommandTest {
         arguments.put("s", "coughing");
         Ui ui = new Ui();
         RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
-        try {
+        assertDoesNotThrow(() -> {
             recordCommand.execute();
-        } catch (Exception exception) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
         TreeMap<LocalDate, Record> records = patient.getRecords();
         assertEquals(1, records.size());
     }
+
+    @Test
+    public void executeRecordCommand_onlyDiagnosis_recordAdded() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "31/03/2021");
+        arguments.put("d", "cold");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        assertDoesNotThrow(() -> {
+            recordCommand.execute();
+        });
+        TreeMap<LocalDate, Record> records = patient.getRecords();
+        assertEquals(1, records.size());
+    }
+
+    @Test
+    public void executeRecordCommand_onlyPrescription_recordAdded() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "31/03/2021");
+        arguments.put("p", "dextromethorphan 1 bottle 1 spoonful after each meal");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        assertDoesNotThrow(() -> {
+            recordCommand.execute();
+        });
+        TreeMap<LocalDate, Record> records = patient.getRecords();
+        assertEquals(1, records.size());
+    }
+
+    @Test
+    public void executeRecordCommand_symptomAndDiagnosis_recordAdded() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "31/03/2021");
+        arguments.put("s", "runny nose, high fever");
+        arguments.put("d", "flu");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        assertDoesNotThrow(() -> {
+            recordCommand.execute();
+        });
+        TreeMap<LocalDate, Record> records = patient.getRecords();
+        assertEquals(1, records.size());
+    }
+
+    @Test
+    public void executeRecordCommand_symptomAndPrescription_recordAdded() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "31/03/2021");
+        arguments.put("s", "runny nose, high fever");
+        arguments.put("p", "paracetamol 200mg 2 tabs daily and cetrizine 1 tab daily");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        assertDoesNotThrow(() -> {
+            recordCommand.execute();
+        });
+        TreeMap<LocalDate, Record> records = patient.getRecords();
+        assertEquals(1, records.size());
+    }
+
 }

--- a/src/test/java/seedu/duke/RecordCommandTest.java
+++ b/src/test/java/seedu/duke/RecordCommandTest.java
@@ -29,7 +29,7 @@ class RecordCommandTest {
         Exception exception = assertThrows(InvalidInputException.class, () -> {
             recordCommand.execute();
         });
-        assertEquals("No patient loaded!", exception.getMessage());
+        assertEquals(Constants.INVALID_INPUT_NO_PATIENT_LOADED, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/seedu/duke/RecordCommandTest.java
+++ b/src/test/java/seedu/duke/RecordCommandTest.java
@@ -146,4 +146,23 @@ class RecordCommandTest {
         assertEquals(1, records.size());
     }
 
+    @Test
+    public void executeRecordCommand_emptyStringAsInputs_recordAdded() {
+        Data data = new Data();
+        Patient patient = new Patient("S1234567D");
+        data.setPatient(patient);
+        data.loadCurrentPatient(patient.getID());
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("command", "record");
+        arguments.put("payload", "31/03/2021");
+        arguments.put("s", "");
+        arguments.put("p", "");
+        Ui ui = new Ui();
+        RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
+        InvalidInputException invalidInputException = assertThrows(InvalidInputException.class, () -> {
+            recordCommand.execute();
+        });
+        assertEquals(Constants.INVALID_INPUT_EMPTY_DESCRIPTION, invalidInputException.getMessage());
+    }
+
 }

--- a/src/test/java/seedu/duke/RecordCommandTest.java
+++ b/src/test/java/seedu/duke/RecordCommandTest.java
@@ -10,7 +10,9 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.TreeMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RecordCommandTest {
     @Test

--- a/src/test/java/seedu/duke/RecordCommandTest.java
+++ b/src/test/java/seedu/duke/RecordCommandTest.java
@@ -147,7 +147,7 @@ class RecordCommandTest {
     }
 
     @Test
-    public void executeRecordCommand_emptyStringAsInputs_recordAdded() {
+    public void executeRecordCommand_emptyStringAsInputs_exceptionThrown() {
         Data data = new Data();
         Patient patient = new Patient("S1234567D");
         data.setPatient(patient);

--- a/src/test/java/seedu/duke/RetrieveCommandTest.java
+++ b/src/test/java/seedu/duke/RetrieveCommandTest.java
@@ -9,8 +9,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RetrieveCommandTest {
     @Test
@@ -40,6 +41,8 @@ class RetrieveCommandTest {
         arguments.put("command", "record");
         arguments.put("payload", "31/03/2021");
         arguments.put("s", "coughing");
+        arguments.put("d", "cold");
+        arguments.put("p", "dextromethorphan 1 bottle 1 spoonful after each meal");
         Ui ui = new Ui();
         RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
         try {
@@ -54,17 +57,18 @@ class RetrieveCommandTest {
         System.setOut(new PrintStream(bos));
 
         RetrieveCommand retrieveCommand = new RetrieveCommand(ui, data, arguments);
-        try {
+        assertDoesNotThrow(() -> {
             retrieveCommand.execute();
-        } catch (Exception exception) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
         String expected = "Here are " + patient.getID() + "'s records:" + System.lineSeparator()
                 + "31/03/2021:" + System.lineSeparator()
                 + "Symptoms:" + System.lineSeparator()
                 + "\tcoughing" + System.lineSeparator()
                 + "Diagnoses:" + System.lineSeparator()
-                + "Prescriptions:" + System.lineSeparator() + System.lineSeparator();
+                + "\tcold" + System.lineSeparator()
+                + "Prescriptions:" + System.lineSeparator()
+                + "\tdextromethorphan 1 bottle 1 spoonful after each meal"
+                + System.lineSeparator() + System.lineSeparator();
         assertEquals(expected, bos.toString());
 
         // Bind System.out back to standard output

--- a/src/test/java/seedu/duke/RetrieveCommandTest.java
+++ b/src/test/java/seedu/duke/RetrieveCommandTest.java
@@ -28,7 +28,7 @@ class RetrieveCommandTest {
         Exception exception = assertThrows(Exception.class, () -> {
             retrieveCommand.execute();
         });
-        assertEquals("No patient loaded!", exception.getMessage());
+        assertEquals(Constants.INVALID_INPUT_NO_PATIENT_LOADED, exception.getMessage());
     }
 
     @Test
@@ -45,11 +45,9 @@ class RetrieveCommandTest {
         arguments.put("p", "dextromethorphan 1 bottle 1 spoonful after each meal");
         Ui ui = new Ui();
         RecordCommand recordCommand = new RecordCommand(ui, data, arguments);
-        try {
+        assertDoesNotThrow(() -> {
             recordCommand.execute();
-        } catch (Exception exception) {
-            System.out.println("An error occurred while running tests");
-        }
+        });
 
         // Bind System.out to a ByteArrayOutputStream
         final PrintStream originalOut = System.out;

--- a/src/test/java/seedu/duke/StorageTest.java
+++ b/src/test/java/seedu/duke/StorageTest.java
@@ -28,11 +28,9 @@ public class StorageTest {
         patient.addRecord(date, "abdominal pain", "mild UTI", "antibiotics, referral to hospital");
         data.setPatient(patient);
 
-        try {
+        assertDoesNotThrow(() -> {
             data.saveFile();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        });
     }
 
     @Test

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -5,7 +5,7 @@ Welcome to the Patient Manager.
 Please input a command: 
 ----------------------------------------------------------------------
 Input command and/or arguments are invalid:
-	Invalid command is provided!
+	Invalid command provided
 ... and is caused by ...
 	java.lang.ClassNotFoundException: seedu.duke.command.Invalid_commandCommand
 ----------------------------------------------------------------------
@@ -26,7 +26,7 @@ List of patients (in alphanumeric order):
 ----------------------------------------------------------------------
 ----------------------------------------------------------------------
 Input command and/or arguments are invalid:
-	Please key in a valid NRIC number!
+	Please key in a valid NRIC number
 ----------------------------------------------------------------------
 ----------------------------------------------------------------------
 Patient S1234567D has been added!
@@ -39,7 +39,7 @@ List of patients (in alphanumeric order):
 ----------------------------------------------------------------------
 ----------------------------------------------------------------------
 Input command and/or arguments are invalid:
-	Kindly use /p or /r to indicate patient or record, refer to help for more clarification!
+	Kindly use /p or /r to indicate patient or record, refer to help for more clarification
 ----------------------------------------------------------------------
 ----------------------------------------------------------------------
 Input command and/or arguments are invalid:


### PR DESCRIPTION
Improve test coverage for the `RecordComand` and `RetrieveCommand` classes.

Other code quality improvements:
- Extract out `parseDate` and `formatDate` as a static methods in the `Common` class.
- Check for argument not specified, as well as empty string as argument\
  i.e. `record /s /p /d` should also throw an error and not execute